### PR TITLE
Fix tf_prefix default argument

### DIFF
--- a/src/ur_description/launch/view_ur.launch.py
+++ b/src/ur_description/launch/view_ur.launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "tf_prefix",
-            default_value='""',
+            default_value="",
             description="Prefix of the joint names for multi-robot setups.",
         )
     )


### PR DESCRIPTION
## Summary
- fix default value for `tf_prefix` argument in UR launch file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_index_python')*

------
https://chatgpt.com/codex/tasks/task_e_6871974ac69c832c857c9be6a2e20286